### PR TITLE
pass reviews count from child component to parent component

### DIFF
--- a/client/src/components/RatingsAndReviews/RatingsAndReviews.jsx
+++ b/client/src/components/RatingsAndReviews/RatingsAndReviews.jsx
@@ -14,6 +14,7 @@ class RatingsAndReviews extends React.Component {
       currentProductId: 0,
       loadMore: true,
       currentReviews: [],
+      currentReviewCount: 0,
       currentDisplayedReviews: [],
       currentMetaReview: sampleMetaReview71697, //default
       // ratingObj: {'5': '0', '4': '0', '3': '0', '2': '0', '1': '0'},
@@ -29,7 +30,10 @@ class RatingsAndReviews extends React.Component {
 
   componentDidMount () {
 
-    this.setState({currentProductId: this.props.currentId});
+    this.setState({
+      currentProductId: this.props.currentId
+
+    });
     this.displayCurrentProductReviews(this.props.currentId);
     this.displayCurrentProductReviewsMeta(this.props.currentId);
 
@@ -45,6 +49,10 @@ class RatingsAndReviews extends React.Component {
       this.displayCurrentProductReviews(this.props.currentId);
 
     }
+    if (this.state.currentReviewCount !== prevState.currentReviewCount) {
+      this.props.passReviewCount(this.state.currentReviewCount);
+
+    }
 
   }
 
@@ -56,6 +64,7 @@ class RatingsAndReviews extends React.Component {
 
         this.setState({
           currentReviews: response.data.results,
+          currentReviewCount: response.data.results.length,
           currentDisplayedReviews: response.data.results.slice(0, 2)
 
         });

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -13,13 +13,14 @@ class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      currentId: 71697,
+      currentId: 0,
       currentAvgRating: 0,
       product: exampleData.productblank,
       productStyle: exampleData.productStyleblank,
       questionsAndAnswers: exampleQuestions,
       outfit: JSON.parse(window.localStorage.getItem('outfit')) || {},
-      hasError: false
+      hasError: false,
+      reviewCount: 0
     };
     this.modifyOutfit = this.modifyOutfit.bind(this);
   }
@@ -112,12 +113,22 @@ class App extends React.Component {
     }
   }
 
+  passReviewCount(count) {
+    this.setState({
+      reviewCount: count
+
+    });
+  }
+
   render () {
+    const {reviewCount} = this.state;
     if (this.state.hasError) {
       return <h1>Oops! Product not found.</h1>;
     } else {
       return (
+
         <div>
+          <h1>current review count:{this.state.reviewCount}</h1>
           <ErrorBoundary>
             <ProductOverview
               currentId={this.state.currentId}
@@ -137,6 +148,8 @@ class App extends React.Component {
             <RatingsAndReviews
               currentId = {this.state.currentId}
               currentProductName = {this.state.product.name}
+              passReviewCount = {this.passReviewCount.bind(this)}
+
             />
           </ErrorBoundary>
         </div>


### PR DESCRIPTION
this update should pass the reviews count from my RatingsAndReviews component to the top layer state. I added a h1 tag showing the current review count number at the top to test. You can delete it later.=)
Also I have change the initial 'currentId' in the top layer state (from 71697 to 0) to avoid the number flash.(otherwise the number will change from initial count:0 to 6(review count of product 71697) and then to the desired product review count).